### PR TITLE
cloudmesh-host improvements

### DIFF
--- a/cloudmesh/host/command/host.py
+++ b/cloudmesh/host/command/host.py
@@ -20,6 +20,7 @@ class HostCommand(PluginCommand):
           Usage:
               host scp NAMES SOURCE DESTINATION [--dryrun]
               host ssh NAMES COMMAND [--dryrun]
+              host key create NAMES [--dryrun]
               host key list NAMES [--dryrun]
               host key fix FILE [--dryrun]
               host key scp NAMES FILE [--dryrun]
@@ -43,6 +44,11 @@ class HostCommand(PluginCommand):
                 runs the command on all specified hosts
                 Example:
                      ssh red[01-10] \"uname -a\"
+
+              host key create NAMES
+                create a ~/.ssh/id_rsa and id_rsa.pub on all hosts specified
+                Example:
+                    ssh key create red[01-10]
 
               host key list NAMES
 
@@ -85,6 +91,11 @@ class HostCommand(PluginCommand):
             names = Parameter.expand(arguments.NAMES)
             results = Host.ssh(names, arguments.COMMAND)
             pprint (results)
+
+        elif arguments.key and arguments.create:
+            names = Parameter.expand(arguments.NAMES)
+            command = "'ssh-keygen -q -N \"\" -f ~/.ssh/id_rsa'"
+            results = Host.ssh(names, command, dryrun=dryrun)
 
         elif arguments.key and arguments.list:
 

--- a/cloudmesh/host/command/host.py
+++ b/cloudmesh/host/command/host.py
@@ -48,7 +48,7 @@ class HostCommand(PluginCommand):
 
                 cats all id_rsa.pub keys from all hosts specifed
                  Example:
-                     ssh key red[01-10] cat
+                     ssh key list red[01-10]
 
               host key fix FILE
 
@@ -90,7 +90,7 @@ class HostCommand(PluginCommand):
 
             names = Parameter.expand(arguments.NAMES)
 
-            command = "cat ~/.ssh/id_rsa.pub"
+            command = "'cat ~/.ssh/id_rsa.pub'"
 
             results = Host.ssh(names, command, dryrun=dryrun)
             # pprint(results)

--- a/cloudmesh/host/command/host.py
+++ b/cloudmesh/host/command/host.py
@@ -58,22 +58,28 @@ class HostCommand(PluginCommand):
 
               host key fix FILE
 
-                not implemented yet
-
-                copies all keys the file FILE to authorized_keys on all hosts
-                but also makes sure the the users ~/.ssh/id_rsa.pub key is in
+                copies all keys from file FILE to authorized_keys on all hosts,
+                but also makes sure that the users ~/.ssh/id_rsa.pub key is in
                 the file.
 
-                1) adds ~/.id_ras.pub to the FILE only if its not already in it
+                1) adds ~/.id_rsa.pub to the FILE only if its not already in it
                 2) removes all duplicated keys
+
+                Example:
+                    ssh key list red[01-10] > pubkeys.txt
+                    ssh key fix pubkeys.txt
 
               host key scp NAMES FILE
 
                 not implemented yet
 
-                copies all keys the file FILE to authorized_keys on all hosts
-                but also makes sure the the users ~/.ssh/id_rsa.pub key is in
-                the file, e.g. it calls fix before upload
+                copies all keys from file FILE to authorized_keys on all hosts
+                but also makes sure that the users ~/.ssh/id_rsa.pub key is in
+                the file and removes duplicates, e.g. it calls fix before upload
+
+                Example:
+                    ssh key list red[01-10] > pubkeys.txt
+                    ssh key scp red[01-10] pubkeys.txt
 
         """
         dryrun = arguments["--dryrun"]

--- a/cloudmesh/host/command/host.py
+++ b/cloudmesh/host/command/host.py
@@ -71,8 +71,6 @@ class HostCommand(PluginCommand):
 
               host key scp NAMES FILE
 
-                not implemented yet
-
                 copies all keys from file FILE to authorized_keys on all hosts
                 but also makes sure that the users ~/.ssh/id_rsa.pub key is in
                 the file and removes duplicates, e.g. it calls fix before upload
@@ -115,38 +113,19 @@ class HostCommand(PluginCommand):
             result = Host.concatenate_keys(results)
 
             if not dryrun:
-                print(result)
+                print(result, end='')
 
         elif arguments.key and arguments.fix:
-
-            #
-            # concatenate ~/.ssh/id_rsa.pub
-            #
-            lines = readfile(arguments.FILE)
-            key = readfile(path_expand("~/.ssh/id_rsa.pub"))
-
-            authorized_keys = lines + key
-
-            #
-            # remove duplicated lines
-            #
-
-            keys = ''.join(authorized_keys)
-            keys = '\n'.join(list(set(keys.splitlines())))
-
-
-            writefile(arguments.FILE, str(keys))
-
+            Host.fix_keys_file(arguments.FILE)
 
         elif arguments.key and arguments.scp:
 
-            source = path_expand("~/.ssh/authorized_keys")
-
+            Host.fix_keys_file(arguments.FILE)
             names = Parameter.expand(arguments.NAMES)
 
             for name in names:
                 destinations = [f"{name}:~/.ssh/authorized_keys"]
-                results = Host.scp(source, destinations, dryrun=dryrun)
+                results = Host.scp(arguments.FILE, destinations, dryrun=dryrun)
 
         print()
 

--- a/cloudmesh/host/host.py
+++ b/cloudmesh/host/host.py
@@ -23,7 +23,7 @@ class Host (object):
         for name in names:
             _command = command.format(name=name)
 
-            print(f"ssh {name} {_command}")
+            _command = f"ssh {name} {_command}"
 
             if not dryrun:
                 result = Shell.run(_command)

--- a/cloudmesh/host/host.py
+++ b/cloudmesh/host/host.py
@@ -24,8 +24,9 @@ class Host (object):
             _command = command.format(name=name)
 
             _command = f"ssh {name} {_command}"
-
-            if not dryrun:
+            if dryrun:
+                print(_command)
+            else:
                 result = Shell.run(_command)
 
                 if output == "lines":

--- a/cloudmesh/host/host.py
+++ b/cloudmesh/host/host.py
@@ -1,4 +1,6 @@
 from cloudmesh.common.Shell import Shell
+from cloudmesh.common.util import readfile, writefile
+from cloudmesh.common.util import path_expand
 from pprint import pprint
 
 class Host (object):
@@ -70,7 +72,22 @@ class Host (object):
         result = ""
         for entry in results:
             name, key = entry
-            key = ' '.join(key)
-            result = result + str(key) + "\n"
+            key = ''.join(key)
+            result += str(key) + '\n'
         result = result.strip()
         return result
+
+    @staticmethod
+    def fix_keys_file(filename):
+        # concatenate ~/.ssh/id_rsa.pub
+        lines = readfile(filename)
+        key = readfile(path_expand("~/.ssh/id_rsa.pub"))
+
+        authorized_keys = lines + key
+        keys = ''.join(authorized_keys)
+
+        # remove duplicates and empty lines
+        keys_list = [x for x in list(set(keys.splitlines())) if x != '\n']
+        keys = ('\n'.join(keys_list) + '\n')
+
+        writefile(filename, str(keys))


### PR DESCRIPTION
Right now 'host ssh' runs the command on the local computer instead of SSHing into the remotes and running the commands there. The first two commits fix that and improve dryrun handling.

Also adds a 'host key create' command, and implements 'host key scp' and improvements to key list + fix.